### PR TITLE
correct wrong cidr var name

### DIFF
--- a/terraform/modules/eks/eks.tf
+++ b/terraform/modules/eks/eks.tf
@@ -194,7 +194,7 @@ resource "aws_security_group" "eks-cluster-sg" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["${var.vpc_cidr_block}"]
+    cidr_blocks = ["${var.aws_vpc_cidr_block}"]
   }
 
   egress {
@@ -216,7 +216,7 @@ ingress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["${var.vpc_cidr_block}"]
+    cidr_blocks = ["${var.aws_vpc_cidr_block}"]
   }
 
   egress {


### PR DESCRIPTION
Error when trying to create:

```
Creating or updating k8s cluster now .... please don't interrupt your terminal ....
╷
│ Error: Reference to undeclared input variable
│
│   on ../../modules/eks/eks.tf line 197, in resource "aws_security_group" "eks-cluster-sg":
│  197:     cidr_blocks = ["${var.vpc_cidr_block}"]
│
│ An input variable with the name "vpc_cidr_block" has not been declared. This variable can be declared with a variable "vpc_cidr_block" {} block.
╵
╷
│ Error: Reference to undeclared input variable
│
│   on ../../modules/eks/eks.tf line 219, in resource "aws_security_group" "eks-node-sg":
│  219:     cidr_blocks = ["${var.vpc_cidr_block}"]
│
│ An input variable with the name "vpc_cidr_block" has not been declared. This variable can be declared with a variable "vpc_cidr_block" {} block.
```

this was declared in `terraform/modules/eks/variables` on line 67: 
```
variable "aws_vpc_cidr_block" {
  type = string
}
```

Fix this by updating line 197 and 219 to have the correct variable name. 