### PR TITLE
Adding fuel core service monitor

### DIFF
--- a/monitoring/serviceMonitors/fuel-core-service-monitor.yaml
+++ b/monitoring/serviceMonitors/fuel-core-service-monitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: fuel-core
+  namespace: <your-fuel-core-namespace>
+  labels:
+    release: kube-prometheus
+spec:
+  selector:
+    matchLabels:
+      app: fuel-core
+  endpoints:
+  - path: /metrics 
+    port: http

--- a/monitoring/values.yaml
+++ b/monitoring/values.yaml
@@ -43,7 +43,7 @@ defaultRules:
     kubeApiserverHistogram: true
     kubeApiserverSlos: true
     kubeControllerManager: false
-    kubelet: true
+    kubelet: false
     kubeProxy: false
     kubePrometheusGeneral: true
     kubePrometheusNodeRecording: true


### PR DESCRIPTION
- add fuel core service monitor
- ignore control plane alerts for eks