### PR TITLE
Adding grafana persistence

### DIFF
--- a/monitoring/values.yaml
+++ b/monitoring/values.yaml
@@ -835,6 +835,15 @@ grafana:
     ##
     pspEnabled: false
 
+  persistence:
+    type: pvc
+    enabled: true
+    accessModes:
+      - ReadWriteOnce
+    size: 10Gi
+    finalizers:
+      - kubernetes.io/pvc-protection
+
   ingress:
     ## If true, Grafana Ingress will be created
     ##


### PR DESCRIPTION
@Voxelot - the reason the grafana passwords kept changing is because the grafana pod would restart and the passowrd would be reset to the original admin password which is prom-operator. 

Now with grafana PVC if grafana pod gets restarted the grafana state e.g. password dashboards, etc will be kept intact with the grafana PVC.

Sorry this took sometime to investigate.