### PR TITLE
Add eks dev sso rbac

### DIFF
--- a/rbac/dev-user-rbac.yaml
+++ b/rbac/dev-user-rbac.yaml
@@ -1,0 +1,29 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: dev-user
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "list", "exec"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: dev-user
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dev-user
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: system:devuser


### PR DESCRIPTION
Need to add EKS DEV SSO RBAC user to just list pods and reduce other permissions 

```
 % kubectl get nodes
Error from server (Forbidden): nodes is forbidden: User "eksdev:yuvraj.singh-fuel.sh" cannot list resource "nodes" in API group "" at the cluster scope

 % kubectl get cm   
Error from server (Forbidden): configmaps is forbidden: User "eksdev:yuvraj.singh-fuel.sh" cannot list resource "configmaps" in API group "" in the namespace "default"

 % kubectl get pods -n fuel-core
NAME                               READY   STATUS    RESTARTS   AGE
fuel-core-k8s-7c5bf6bd8c-hvczk     1/1     Running   0          25h
fuel-faucet-k8s-6d96456fb5-7g7zg   1/1     Running   0          69d
```