### PR TITLE
Create EBS Snapshot script

### DIFF
--- a/scripts/create-ebs-snapshot.sh
+++ b/scripts/create-ebs-snapshot.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+echo "Please authenticate to your cluster first ...."
+
+echo "Please enter your k8s namespace ...."
+read NAMESPACE
+
+echo "Please enter your fuel-core service name e.g. authority, sentry-1, sentry-2 ...."
+read SERVICE
+
+export PVC_NAME=$(kubectl get pv | grep $NAMESPACE/$SERVICE-db-pv-claim | awk '{print $1}')
+
+echo "The PVC name you have selected is $PVC_NAME ...."
+
+export ORG_SNAPSHOT_ID=$(kubectl get pv $PVC_NAME --output=jsonpath='{.spec.awsElasticBlockStore.volumeID}')
+
+echo "The Source Snapshot ID you have elected is $ORG_SNAPSHOT_ID ...." 
+
+echo "Creating EBS snapshot of $NAMESPACE/$SERVICE-db-pv-claim ...."
+aws ec2 create-snapshot --volume-id $ORG_SNAPSHOT_ID
+
+echo "Enter your SnapshotId from above command output ...."
+read FINAL_SNAPSHOT_ID
+
+echo "Wait until you Progress is 100% before deploying fuel-core ...."
+aws ec2 describe-snapshots --snapshot-ids $FINAL_SNAPSHOT_ID
+echo "Make sure to use $FINAL_SNAPSHOT_ID for fuel_core_pvc_snapshot_ref in fuel-deployment env file"
+


### PR DESCRIPTION
this creates the EBS Snapshot that is used to clone PVCs for sentries, etc. in conjunction with https://github.com/FuelLabs/fuel-core/pull/1115

User must run this script and enter:

- the namesapce
- the fuel-core service e.g. sentry-1, sentry-2, sentry-3

then wait for the snapshot to be taken so its progress 100%