### PR TITLE
Upgrade Terraform Modules v1

### DIFF
--- a/scripts/create-k8s.sh
+++ b/scripts/create-k8s.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+# This script may be used to initialize and deploy our EKS Kubernetes cluster. At some point, however, we
+# should replace this thing with an Ansible playbook.
+
+# It would be nice to provide reasonable defaults for the half-dozen environment variables expected to be
+# bound before this script is run; however, that might not be possible. Needs investigation.
+
 set -o pipefail -o errexit -o nounset
 
 readonly progname=$(basename $0)
@@ -10,21 +16,251 @@ set +o allexport
 
 readonly k8s_root=$(pwd)/..  # we're assuming that this script is run from its home directory (scripts)
 
-export tstate=state.tf
-export tform_env=$k8s_root/terraform/environments/$k8s_provider
+readonly helm_url='https://charts.jetstack.io'
+readonly certman_version='v1.7.1'
+
+readonly nginx_url='https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/aws/deploy.yaml'
+readonly prometheus_helm_url='https://prometheus-community.github.io/helm-charts'
+
+readonly cloudwatch_k8s_url='https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/latest'
+readonly cloudwatch_url="$cloudwatch_k8s_url/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml"
+
+usage() {
+    cat <<EOF
+Usage: $progname [OPTIONS]
+
+This script may be used to initialize and deploy our EKS Kubernetes cluster. By default, all setup tasks
+are run. This may be controlled via the use of command-line arguments.
+
+The following environment variables are expected to be defined for this script to function properly:
+  - TF_VAR_eks_cluster_name
+  - TF_VAR_aws_region
+  - k8s_provider
+
+Options:
+  -c   Set up the kube context only.
+  -e   Set up EKS only.
+  -m   Set up monitoring only.
+  -n   Set up nginx only.
+  -p   Set up Prometheus only.
+  -t   Set up Terraform only.
+  -py  Set up pyro only
+  -h   Show this message and exit.
+
+Notes:
+  - At present, only 'eks' is supported for k8s_provider.
+EOF
+
+    exit 1
+}
+
+fail() {
+    local funcname=''
     
-pushd $tform_env
+    [[ $1 == -v ]] && { funcname="${FUNCNAME[1]}: "; shift; }
+    
+    local msg="$@"
 
-mv $tstate state.template
-envsubst < state.template > $tstate
-rm -f state.template 
+    >&2 echo "$progname: $funcname $msg"
 
-echo "Initializing terraform environment..."
+    exit 1
+}
 
-terraform init
+pushd() {
+    local args="$@"
 
-echo "Creating or updating K8s cluster now. Please don't interrupt your terminal!"
+    command pushd $args > /dev/null
+}
 
-terraform plan
+popd() {
+    command popd > /dev/null
+}
 
+setup_terraform() {
+    [[ $k8s_provider == eks ]] || fail -v "currently, only 'eks' is supported as the Kubernetes provider"
 
+    local tstate=state.tf
+    local tform_env=$k8s_root/terraform/environments/$k8s_provider
+    
+    pushd $tform_env
+
+    mv $tstate state.template
+    envsubst < state.template > $tstate
+    rm -f state.template 
+
+    echo "Initializing terraform environment..."
+    
+    terraform init
+
+    echo "Creating or updating K8s cluster now. Please don't interrupt your terminal!"
+
+    terraform apply -auto-approve
+
+    echo "Please wait while your K8s cluster is configured."
+
+    popd
+}
+
+setup_kube_context() {
+    local issuer='prod-issuer.yaml'
+    
+    pushd ../ingress
+
+    echo "Updating local kube context..."
+    
+    aws eks update-kubeconfig --name $TF_VAR_eks_cluster_name --region $TF_VAR_aws_region
+    
+    echo "Deploying cert-manager helm chart to $TF_VAR_eks_cluster_name..."
+
+    helm repo add jetstack $helm_url
+    helm repo update
+
+    helm upgrade cert-manager jetstack/cert-manager --set installCRDs=true --namespace cert-manager --version $certman_version --install --create-namespace --wait --timeout 8000s --debug 
+
+    echo "Deploying production cluster issuer to $TF_VAR_eks_cluster_name..."
+
+    mv $issuer prod-issuer.template
+    
+    envsubst < prod-issuer.template > $issuer
+    rm -f prod-issuer.template
+
+    kubectl apply -f $issuer
+
+    popd
+}
+
+setup_nginx() {
+    echo "Deploying nginx ingress controller to $TF_VAR_eks_cluster_name..."
+    
+    kubectl apply -f $nginx_url
+
+    sleep 180  # We need a better way to determine readiness
+}
+
+setup_prometheus() {
+    local values_env='values.yaml'
+    
+    echo "Deploying kube-prometheus helm chart to $TF_VAR_eks_cluster_name..."
+
+    pushd ../monitoring
+
+    mv $values_env values.template
+    envsubst < values.template > $values_env
+
+    rm -f values.template
+
+    helm repo add prometheus-community $prometheus_helm_url
+    helm repo update
+
+    helm delete kube-prometheus --namespace monitoring || echo "$progname: kube-prometheus not loaded: ignoring..."
+    helm upgrade kube-prometheus prometheus-community/kube-prometheus-stack --values $values_env --install --create-namespace --namespace=monitoring --wait --timeout 8000s --debug --version ^34
+
+    popd
+}
+
+setup_monitoring() {
+    local mon_ingress='monitoring-ingress.yaml'
+    
+    pushd ../ingress
+
+    echo "Deploying monitoring ingress to $TF_VAR_eks_cluster_name..."
+
+    mv $mon_ingress monitoring-ingress.template
+    envsubst < monitoring-ingress.template > $mon_ingress
+    
+    rm -f monitoring-ingress.template
+
+    kubectl apply -f $mon_ingress
+
+    popd
+}
+
+setup_eks_container() {
+    echo "Deploying AWS EKS Container Insights to $TF_VAR_eks_cluster_name..."
+    
+    export ClusterName=$TF_VAR_eks_cluster_name
+    export RegionName=$TF_VAR_aws_region
+    export FluentBitHttpPort='2020'
+    export FluentBitReadFromHead='Off'
+
+    [[ $FluentBitReadFromHead = 'On' ]] && FluentBitReadFromTail='Off'|| FluentBitReadFromTail='On'
+    [[ -z $FluentBitHttpPort ]] && FluentBitHttpServer='Off' || FluentBitHttpServer='On'
+
+    local doc=$(curl $cloudwatch_url | sed 's/{{cluster_name}}/'${ClusterName}'/;s/{{region_name}}/'${RegionName}'/;s/{{http_server_toggle}}/"'${FluentBitHttpServer}'"/;s/{{http_server_port}}/"'${FluentBitHttpPort}'"/;s/{{read_from_head}}/"'${FluentBitReadFromHead}'"/;s/{{read_from_tail}}/"'${FluentBitReadFromTail}'"/')
+
+    echo "$doc" | kubectl apply -f -
+
+    return 0
+}
+
+setup_pyro() {
+    echo "Deploying pyro to $TF_VAR_eks_cluster_name..."
+    
+    helm repo add pyroscope-io https://pyroscope-io.github.io/helm-chart
+    helm install pyroscope pyroscope-io/pyroscope --namespace monitoring
+    kubectl get pods -n monitoring | grep pyro
+ 
+}
+
+sanity_checks() {
+    [[ -n $k8s_provider ]] || fail -v "k8s_provider is unbound!"
+    [[ -n $TF_VAR_eks_cluster_name ]] || fail -v "TF_VAR_eks_cluster_name is unbound!"
+    [[ -n $TF_VAR_aws_region ]] || fail -v "TF_VAR_aws_region is unbound!"
+
+    [[ $k8s_provider == eks ]] || fail -v "only 'eks' is supported for k8s_provider ($k8s_provider)!"
+}
+
+error_handler() {
+    local rc="$1"
+    local line="$2"
+    
+    >&2 echo "$progname: non-recoverable error at line $line ($rc)."
+}
+
+setup_all() {
+    setup_terraform
+    setup_kube_context
+    setup_nginx
+    setup_prometheus
+    setup_monitoring
+    setup_eks_container
+    setup_pyro
+}
+
+# --- main() ---
+
+task='all'
+
+while getopts "cemnpth" opt ; do
+    case $opt in
+        c) task=context ;;
+        e) task=eks ;;
+        m) task=monitor ;;
+        n) task=nginx ;;
+        p) task=prometheus ;;
+        t) task=terraform ;;
+        py) task=pyro ;;
+        h) usage ;;
+        *) usage ;;
+    esac
+done
+
+shift $((OPTIND - 1))
+
+trap 'error_handler $? $LINENO' ERR
+
+sanity_checks
+
+case $task in
+    all) setup_all ;;
+    terraform) setup_terraform ;;
+    context) setup_kube_context ;;
+    nginx) setup_nginx ;;
+    prometheus) setup_prometheus ;;
+    monitor) setup_monitoring ;;
+    eks) setup_eks_container ;;
+    pyro) setup_pyro ;;
+    *) usage ;;
+esac
+
+exit 0

--- a/scripts/create-k8s.sh
+++ b/scripts/create-k8s.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 
-# This script may be used to initialize and deploy our EKS Kubernetes cluster. At some point, however, we
-# should replace this thing with an Ansible playbook.
-
-# It would be nice to provide reasonable defaults for the half-dozen environment variables expected to be
-# bound before this script is run; however, that might not be possible. Needs investigation.
-
 set -o pipefail -o errexit -o nounset
 
 readonly progname=$(basename $0)
@@ -16,251 +10,21 @@ set +o allexport
 
 readonly k8s_root=$(pwd)/..  # we're assuming that this script is run from its home directory (scripts)
 
-readonly helm_url='https://charts.jetstack.io'
-readonly certman_version='v1.7.1'
-
-readonly nginx_url='https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/aws/deploy.yaml'
-readonly prometheus_helm_url='https://prometheus-community.github.io/helm-charts'
-
-readonly cloudwatch_k8s_url='https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/latest'
-readonly cloudwatch_url="$cloudwatch_k8s_url/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml"
-
-usage() {
-    cat <<EOF
-Usage: $progname [OPTIONS]
-
-This script may be used to initialize and deploy our EKS Kubernetes cluster. By default, all setup tasks
-are run. This may be controlled via the use of command-line arguments.
-
-The following environment variables are expected to be defined for this script to function properly:
-  - TF_VAR_eks_cluster_name
-  - TF_VAR_aws_region
-  - k8s_provider
-
-Options:
-  -c   Set up the kube context only.
-  -e   Set up EKS only.
-  -m   Set up monitoring only.
-  -n   Set up nginx only.
-  -p   Set up Prometheus only.
-  -t   Set up Terraform only.
-  -py  Set up pyro only
-  -h   Show this message and exit.
-
-Notes:
-  - At present, only 'eks' is supported for k8s_provider.
-EOF
-
-    exit 1
-}
-
-fail() {
-    local funcname=''
+local tstate=state.tf
+local tform_env=$k8s_root/terraform/environments/$k8s_provider
     
-    [[ $1 == -v ]] && { funcname="${FUNCNAME[1]}: "; shift; }
-    
-    local msg="$@"
+pushd $tform_env
 
-    >&2 echo "$progname: $funcname $msg"
+mv $tstate state.template
+envsubst < state.template > $tstate
+rm -f state.template 
 
-    exit 1
-}
+echo "Initializing terraform environment..."
 
-pushd() {
-    local args="$@"
+terraform init
 
-    command pushd $args > /dev/null
-}
+echo "Creating or updating K8s cluster now. Please don't interrupt your terminal!"
 
-popd() {
-    command popd > /dev/null
-}
+terraform plan
 
-setup_terraform() {
-    [[ $k8s_provider == eks ]] || fail -v "currently, only 'eks' is supported as the Kubernetes provider"
 
-    local tstate=state.tf
-    local tform_env=$k8s_root/terraform/environments/$k8s_provider
-    
-    pushd $tform_env
-
-    mv $tstate state.template
-    envsubst < state.template > $tstate
-    rm -f state.template 
-
-    echo "Initializing terraform environment..."
-    
-    terraform init
-
-    echo "Creating or updating K8s cluster now. Please don't interrupt your terminal!"
-
-    terraform plan
-
-    echo "Please wait while your K8s cluster is configured."
-
-    popd
-}
-
-setup_kube_context() {
-    local issuer='prod-issuer.yaml'
-    
-    pushd ../ingress
-
-    echo "Updating local kube context..."
-    
-    aws eks update-kubeconfig --name $TF_VAR_eks_cluster_name --region $TF_VAR_aws_region
-    
-    echo "Deploying cert-manager helm chart to $TF_VAR_eks_cluster_name..."
-
-    helm repo add jetstack $helm_url
-    helm repo update
-
-    helm upgrade cert-manager jetstack/cert-manager --set installCRDs=true --namespace cert-manager --version $certman_version --install --create-namespace --wait --timeout 8000s --debug 
-
-    echo "Deploying production cluster issuer to $TF_VAR_eks_cluster_name..."
-
-    mv $issuer prod-issuer.template
-    
-    envsubst < prod-issuer.template > $issuer
-    rm -f prod-issuer.template
-
-    kubectl apply -f $issuer
-
-    popd
-}
-
-setup_nginx() {
-    echo "Deploying nginx ingress controller to $TF_VAR_eks_cluster_name..."
-    
-    kubectl apply -f $nginx_url
-
-    sleep 180  # We need a better way to determine readiness
-}
-
-setup_prometheus() {
-    local values_env='values.yaml'
-    
-    echo "Deploying kube-prometheus helm chart to $TF_VAR_eks_cluster_name..."
-
-    pushd ../monitoring
-
-    mv $values_env values.template
-    envsubst < values.template > $values_env
-
-    rm -f values.template
-
-    helm repo add prometheus-community $prometheus_helm_url
-    helm repo update
-
-    helm delete kube-prometheus --namespace monitoring || echo "$progname: kube-prometheus not loaded: ignoring..."
-    helm upgrade kube-prometheus prometheus-community/kube-prometheus-stack --values $values_env --install --create-namespace --namespace=monitoring --wait --timeout 8000s --debug --version ^34
-
-    popd
-}
-
-setup_monitoring() {
-    local mon_ingress='monitoring-ingress.yaml'
-    
-    pushd ../ingress
-
-    echo "Deploying monitoring ingress to $TF_VAR_eks_cluster_name..."
-
-    mv $mon_ingress monitoring-ingress.template
-    envsubst < monitoring-ingress.template > $mon_ingress
-    
-    rm -f monitoring-ingress.template
-
-    kubectl apply -f $mon_ingress
-
-    popd
-}
-
-setup_eks_container() {
-    echo "Deploying AWS EKS Container Insights to $TF_VAR_eks_cluster_name..."
-    
-    export ClusterName=$TF_VAR_eks_cluster_name
-    export RegionName=$TF_VAR_aws_region
-    export FluentBitHttpPort='2020'
-    export FluentBitReadFromHead='Off'
-
-    [[ $FluentBitReadFromHead = 'On' ]] && FluentBitReadFromTail='Off'|| FluentBitReadFromTail='On'
-    [[ -z $FluentBitHttpPort ]] && FluentBitHttpServer='Off' || FluentBitHttpServer='On'
-
-    local doc=$(curl $cloudwatch_url | sed 's/{{cluster_name}}/'${ClusterName}'/;s/{{region_name}}/'${RegionName}'/;s/{{http_server_toggle}}/"'${FluentBitHttpServer}'"/;s/{{http_server_port}}/"'${FluentBitHttpPort}'"/;s/{{read_from_head}}/"'${FluentBitReadFromHead}'"/;s/{{read_from_tail}}/"'${FluentBitReadFromTail}'"/')
-
-    echo "$doc" | kubectl apply -f -
-
-    return 0
-}
-
-setup_pyro() {
-    echo "Deploying pyro to $TF_VAR_eks_cluster_name..."
-    
-    helm repo add pyroscope-io https://pyroscope-io.github.io/helm-chart
-    helm install pyroscope pyroscope-io/pyroscope --namespace monitoring
-    kubectl get pods -n monitoring | grep pyro
- 
-}
-
-sanity_checks() {
-    [[ -n $k8s_provider ]] || fail -v "k8s_provider is unbound!"
-    [[ -n $TF_VAR_eks_cluster_name ]] || fail -v "TF_VAR_eks_cluster_name is unbound!"
-    [[ -n $TF_VAR_aws_region ]] || fail -v "TF_VAR_aws_region is unbound!"
-
-    [[ $k8s_provider == eks ]] || fail -v "only 'eks' is supported for k8s_provider ($k8s_provider)!"
-}
-
-error_handler() {
-    local rc="$1"
-    local line="$2"
-    
-    >&2 echo "$progname: non-recoverable error at line $line ($rc)."
-}
-
-setup_all() {
-    setup_terraform
-    setup_kube_context
-    setup_nginx
-    setup_prometheus
-    setup_monitoring
-    setup_eks_container
-    setup_pyro
-}
-
-# --- main() ---
-
-task='all'
-
-while getopts "cemnpth" opt ; do
-    case $opt in
-        c) task=context ;;
-        e) task=eks ;;
-        m) task=monitor ;;
-        n) task=nginx ;;
-        p) task=prometheus ;;
-        t) task=terraform ;;
-        py) task=pyro ;;
-        h) usage ;;
-        *) usage ;;
-    esac
-done
-
-shift $((OPTIND - 1))
-
-trap 'error_handler $? $LINENO' ERR
-
-sanity_checks
-
-case $task in
-    all) setup_all ;;
-    terraform) setup_terraform ;;
-    context) setup_kube_context ;;
-    nginx) setup_nginx ;;
-    prometheus) setup_prometheus ;;
-    monitor) setup_monitoring ;;
-    eks) setup_eks_container ;;
-    pyro) setup_pyro ;;
-    *) usage ;;
-esac
-
-exit 0

--- a/scripts/create-k8s.sh
+++ b/scripts/create-k8s.sh
@@ -94,7 +94,7 @@ setup_terraform() {
 
     echo "Creating or updating K8s cluster now. Please don't interrupt your terminal!"
 
-    terraform apply -auto-approve
+    terraform plan
 
     echo "Please wait while your K8s cluster is configured."
 

--- a/scripts/create-k8s.sh
+++ b/scripts/create-k8s.sh
@@ -10,8 +10,8 @@ set +o allexport
 
 readonly k8s_root=$(pwd)/..  # we're assuming that this script is run from its home directory (scripts)
 
-local tstate=state.tf
-local tform_env=$k8s_root/terraform/environments/$k8s_provider
+export tstate=state.tf
+export tform_env=$k8s_root/terraform/environments/$k8s_provider
     
 pushd $tform_env
 

--- a/terraform/modules/eks/eks.tf
+++ b/terraform/modules/eks/eks.tf
@@ -29,7 +29,7 @@ module "eks" {
 resource "aws_eks_addon" "core_dns" {
   cluster_name = "${var.eks_cluster_name}"
   addon_name        = "coredns"
-  addon_version     = "v1.10.1-eksbuild.1"
+  addon_version     = "v1.9.3-eksbuild.5"
   resolve_conflicts = "OVERWRITE"
   depends_on = [
     aws_eks_node_group.nodes,

--- a/terraform/modules/eks/eks.tf
+++ b/terraform/modules/eks/eks.tf
@@ -1,7 +1,7 @@
 # EKS Cluster
 module "eks" {
   source = "terraform-aws-modules/eks/aws"
-  version = "18.29.0"
+  version = "19.15.3"
 
   cluster_name                    = "${var.eks_cluster_name}"
   cluster_version                 = "${var.eks_cluster_version}"

--- a/terraform/modules/eks/eks.tf
+++ b/terraform/modules/eks/eks.tf
@@ -6,7 +6,7 @@ module "eks" {
   cluster_name                    = "${var.eks_cluster_name}"
   cluster_version                 = "${var.eks_cluster_version}"
   cluster_endpoint_private_access = true
-  cluster_endpoint_public_access  = true
+  cluster_endpoint_public_access  = false
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
@@ -216,11 +216,11 @@ resource "aws_security_group" "eks-cluster-sg" {
   vpc_id        = module.vpc.vpc_id
 
   ingress {
-    description = "Allow Public Traffic"
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks =  ["0.0.0.0/0"]
+    description = "Allow VPC Traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["${var.aws_vpc_cidr_block}"]
   }
 
   ingress {

--- a/terraform/modules/eks/eks.tf
+++ b/terraform/modules/eks/eks.tf
@@ -27,7 +27,7 @@ module "eks" {
 
 # EKS Cluster CoreDNS Cluster Add On 
 resource "aws_eks_addon" "core_dns" {
-  cluster_name = module.eks.cluster_id
+  cluster_name = "${var.eks_cluster_name}"
   addon_name        = "coredns"
   addon_version     = "v1.10.1-eksbuild.1"
   resolve_conflicts = "OVERWRITE"
@@ -38,7 +38,7 @@ resource "aws_eks_addon" "core_dns" {
 
 # EKS Cluster EBS CSI Driver Cluster Add On 
 resource "aws_eks_addon" "ebs_csi_driver" {
-  cluster_name = module.eks.cluster_id
+  cluster_name = "${var.eks_cluster_name}"
   addon_name        = "aws-ebs-csi-driver"
   addon_version     = "v1.19.0-eksbuild.1"
   resolve_conflicts = "OVERWRITE"

--- a/terraform/modules/eks/eks.tf
+++ b/terraform/modules/eks/eks.tf
@@ -90,6 +90,8 @@ resource "aws_eks_node_group" "nodes" {
     aws_iam_role_policy_attachment.AmazonEKSWorkerNodePolicy,
     aws_iam_role_policy_attachment.AmazonEKS_CNI_Policy,
     aws_iam_role_policy_attachment.AmazonEC2ContainerRegistryReadOnly,
+    module.eks
+
   ]
 }
 

--- a/terraform/modules/eks/eks.tf
+++ b/terraform/modules/eks/eks.tf
@@ -77,11 +77,6 @@ resource "aws_eks_node_group" "nodes" {
     min_size     = var.eks_node_min_size
   }
 
-  remote_access {
-    ec2_ssh_key = var.ec2_ssh_key 
-    source_security_group_ids = [aws_security_group.eks-node-sg.id]
-  }
-
   update_config {
     max_unavailable = 1
   }

--- a/terraform/modules/eks/eks.tf
+++ b/terraform/modules/eks/eks.tf
@@ -49,7 +49,7 @@ resource "aws_eks_addon" "ebs_csi_driver" {
 
 # EKS Node Group
 resource "aws_eks_node_group" "nodes" {
-  cluster_name    = module.eks.cluster_id
+  cluster_name    = "${var.eks_cluster_name}"
   node_group_name = var.eks_node_groupname
   node_role_arn   = aws_iam_role.eks-nodegroup-iam-role.arn
   subnet_ids      = module.vpc.private_subnets

--- a/terraform/modules/eks/eks.tf
+++ b/terraform/modules/eks/eks.tf
@@ -8,39 +8,52 @@ module "eks" {
   cluster_endpoint_private_access = true
   cluster_endpoint_public_access  = true
 
-  cluster_addons = {
-    kube-proxy = {
-      most_recent = true
-    }
-    vpc-cni = {
-      most_recent = true
-    }
-  }
-
   vpc_id     = module.vpc.vpc_id
-  subnet_ids = concat(module.vpc.public_subnets, module.vpc.private_subnets)
+  subnet_ids = module.vpc.private_subnets
   create_iam_role = false
   iam_role_arn = aws_iam_role.eks-cluster-iam-role.arn
   create_cluster_security_group= false
   cluster_security_group_id = aws_security_group.eks-cluster-sg.id
 }
 
-# EKS Cluster CoreDNS Cluster Add On 
+# EKS Cluster CoreDNS Add On 
 resource "aws_eks_addon" "core_dns" {
   cluster_name = "${var.eks_cluster_name}"
   addon_name        = "coredns"
-  addon_version     = "v1.9.3-eksbuild.5"
+  addon_version     = "v1.10.1-eksbuild.2"
   resolve_conflicts = "OVERWRITE"
   depends_on = [
     aws_eks_node_group.nodes,
   ]
 }
 
-# EKS Cluster EBS CSI Driver Cluster Add On 
+# EKS Cluster EBS CSI Driver Add On 
 resource "aws_eks_addon" "ebs_csi_driver" {
   cluster_name = "${var.eks_cluster_name}"
   addon_name        = "aws-ebs-csi-driver"
-  addon_version     = "v1.19.0-eksbuild.1"
+  addon_version     = "v1.20.0-eksbuild.1"
+  resolve_conflicts = "OVERWRITE"
+  depends_on = [
+    aws_eks_node_group.nodes,
+  ]
+}
+
+# EKS Cluster VPC CNI Cluster Add On
+resource "aws_eks_addon" "vpc_cni" {
+  cluster_name = "${var.eks_cluster_name}"
+  addon_name   = "vpc-cni"
+  addon_version     = "v1.13.2-eksbuild.1"
+  resolve_conflicts = "OVERWRITE"
+  depends_on = [
+    aws_eks_node_group.nodes,
+  ]
+}
+
+# EKS Cluster Kube-Proxy Add On
+resource "aws_eks_addon" "kube_proxy" {
+  cluster_name = "${var.eks_cluster_name}"
+  addon_name   = "kube-proxy"
+  addon_version     = "v1.27.3-eksbuild.1"
   resolve_conflicts = "OVERWRITE"
   depends_on = [
     aws_eks_node_group.nodes,

--- a/terraform/modules/eks/eks.tf
+++ b/terraform/modules/eks/eks.tf
@@ -6,7 +6,7 @@ module "eks" {
   cluster_name                    = "${var.eks_cluster_name}"
   cluster_version                 = "${var.eks_cluster_version}"
   cluster_endpoint_private_access = true
-  cluster_endpoint_public_access  = false
+  cluster_endpoint_public_access  = true
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets

--- a/terraform/modules/eks/versions.tf
+++ b/terraform/modules/eks/versions.tf
@@ -1,3 +1,4 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 1.0"
 }
+

--- a/terraform/modules/eks/vpc.tf
+++ b/terraform/modules/eks/vpc.tf
@@ -28,8 +28,8 @@ module "vpc" {
   private_subnet_tags = local.private_subnet_eks_tag
 
   enable_nat_gateway     = true
-  single_nat_gateway     = false
-  one_nat_gateway_per_az = true
+  single_nat_gateway     = true
+  one_nat_gateway_per_az = false
   enable_dns_hostnames   = true
   enable_dns_support     = true
 

--- a/terraform/modules/eks/vpc.tf
+++ b/terraform/modules/eks/vpc.tf
@@ -27,7 +27,11 @@ module "vpc" {
   private_subnets     = var.aws_private_subnets
   private_subnet_tags = local.private_subnet_eks_tag
 
-  enable_nat_gateway = true
-  single_nat_gateway = false
+  enable_nat_gateway     = true
+  single_nat_gateway     = false
+  one_nat_gateway_per_az = true
+  enable_dns_hostnames   = true
+  enable_dns_support     = true
+
   tags               = merge(local.environment_tag, local.vpc_eks_tag)
 }

--- a/terraform/modules/eks/vpc.tf
+++ b/terraform/modules/eks/vpc.tf
@@ -28,6 +28,6 @@ module "vpc" {
   private_subnet_tags = local.private_subnet_eks_tag
 
   enable_nat_gateway = true
-  single_nat_gateway = true
+  single_nat_gateway = false
   tags               = merge(local.environment_tag, local.vpc_eks_tag)
 }

--- a/terraform/modules/eks/vpc.tf
+++ b/terraform/modules/eks/vpc.tf
@@ -16,7 +16,7 @@ locals {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.11.0"
+  version = "5.0.0"
 
   name = var.aws_environment
   cidr = var.aws_vpc_cidr_block


### PR DESCRIPTION
Changes made:

- update vpc and eks modules versions
- update required terraform version
- add vpc_cni and kube_proxy add on as selectable versions
- remove ssh access from eks node groups

Note:

too many breaking changes for existing PROD and DEV- refactor of TFE will replace these clusters

This effort is only for external/outside Fuel users who maybe using our infra repo to deploy their own clusters